### PR TITLE
Add `format` script

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"],
+  "organizeImportsSkipDestructiveCodeActions": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@types/pg": "^8.15.5",
         "eslint": "^9.34.0",
         "nodemon": "^3.1.10",
+        "prettier": "^3.6.2",
+        "prettier-plugin-organize-imports": "^4.3.0",
         "typescript": "^5.9.2"
       }
     },
@@ -1991,6 +1993,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "nodemon",
     "start": "tsc && node ./dist/index.js",
-    "build": "tsc"
+    "build": "tsc",
+    "format": "prettier --write \"./src/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,8 @@
     "@types/pg": "^8.15.5",
     "eslint": "^9.34.0",
     "nodemon": "^3.1.10",
+    "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "typescript": "^5.9.2"
   },
   "nodemonConfig": {


### PR DESCRIPTION
Run `npm run format` to format all code under `src/` with Prettier. Also add `prettier-plugin-organize-imports` to sort imports in a consistent order.